### PR TITLE
Loaded font-awesome css before PrimeNG css

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -19,9 +19,9 @@
       "testTsconfig": "tsconfig.spec.json",
       "prefix": "app",
       "styles": [
+        "../node_modules/font-awesome/css/font-awesome.min.css",
         "../node_modules/primeng/resources/primeng.css",
         "../node_modules/primeng/resources/themes/omega/theme.css",
-        "../node_modules/font-awesome/css/font-awesome.min.css",
         "styles.css"
       ],
       "scripts": [],


### PR DESCRIPTION
The getting started docs mention this: "note that font-awesome should be loaded before PrimeNG css"